### PR TITLE
Make default routes configurable

### DIFF
--- a/src/Http/DefaultRouteChecker.php
+++ b/src/Http/DefaultRouteChecker.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Sylius Force Customer Login package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace BitExpert\SyliusForceCustomerLoginPlugin\Http;
+
+final readonly class DefaultRouteChecker implements DefaultRouteCheckerInterface
+{
+    public function isDefaultRoute(string $route): bool
+    {
+        if (str_starts_with($route, '/_wdt') ||
+            str_starts_with($route, '/_profiler') ||
+            str_starts_with($route, '/api') ||
+            str_starts_with($route, '/admin') ||
+            str_contains($route, '/login') ||
+            str_contains($route, '/register') ||
+            str_contains($route, '/cart') ||
+            str_contains($route, '/checkout') ||
+            str_contains($route, '/ajax')) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Http/DefaultRouteCheckerInterface.php
+++ b/src/Http/DefaultRouteCheckerInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Sylius Force Customer Login package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace BitExpert\SyliusForceCustomerLoginPlugin\Http;
+
+interface DefaultRouteCheckerInterface
+{
+    public function isDefaultRoute(string $route): bool;
+}

--- a/src/Resources/config/services/security.xml
+++ b/src/Resources/config/services/security.xml
@@ -4,8 +4,11 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="bitexpert.sylius_force_customer_login_plugin.default_route_checker" class="BitExpert\SyliusForceCustomerLoginPlugin\Http\DefaultRouteChecker" />
+
         <service id="BitExpert\SyliusForceCustomerLoginPlugin\Events\ForceLoginRequestEvent">
             <argument type="service" id="Symfony\Bundle\SecurityBundle\Security" />
+            <argument type="service" id="bitexpert.sylius_force_customer_login_plugin.default_route_checker" />
             <argument>%locale%</argument>
             <tag name="kernel.event_subscriber" />
         </service>

--- a/tests/Unit/Events/ForceLoginRequestEventTest.php
+++ b/tests/Unit/Events/ForceLoginRequestEventTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Tests\BitExpert\SyliusForceCustomerLoginPlugin\Unit\Events;
 
 use BitExpert\SyliusForceCustomerLoginPlugin\Events\ForceLoginRequestEvent;
+use BitExpert\SyliusForceCustomerLoginPlugin\Http\DefaultRouteChecker;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -26,13 +27,16 @@ class ForceLoginRequestEventTest extends \PHPUnit\Framework\TestCase
 
     private ForceLoginRequestEvent $forceLoginRequestEvent;
 
+    private DefaultRouteChecker $defaultRouteCheck;
+
     protected function setUp(): void
     {
         $locale = 'en';
 
         $this->securityMock = $this->createMock(Security::class);
         $this->eventMock = $this->createMock(RequestEvent::class);
-        $this->forceLoginRequestEvent = new ForceLoginRequestEvent($this->securityMock, $locale);
+        $this->defaultRouteCheck = new DefaultRouteChecker();
+        $this->forceLoginRequestEvent = new ForceLoginRequestEvent($this->securityMock, $this->defaultRouteCheck, $locale);
     }
 
     /**
@@ -113,7 +117,6 @@ class ForceLoginRequestEventTest extends \PHPUnit\Framework\TestCase
     public function whitelistedUrls(): array
     {
         return [
-            ['/'],
             ['/_wdt'],
             ['/profiler'],
             ['/admin'],


### PR DESCRIPTION
Extract the default route definitions to ensure this can be customized according to the project's requirements.