### PR TITLE
Switch to phpstan-sylius stable release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "sylius/sylius": "^2.1"
     },
     "require-dev": {
-        "bitexpert/phpstan-sylius": "dev-master",
+        "bitexpert/phpstan-sylius": "^0.1",
         "captainhook/captainhook": "^5.19",
         "captainhook/plugin-composer": "^5.3",
         "ergebnis/composer-normalize": "^2.47",


### PR DESCRIPTION
Switching the dependency to the stable version instead of relying on dev-master